### PR TITLE
Fix chart ref to master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -279,15 +279,9 @@ jobs:
 
           if [ "${{ matrix.environment }}" = "staging" ]; then
 
-            export CHART_REF="$GITHUB_HEAD_REF"
-
-            # $GITHUB_HEAD_REF references the source branch of the pull request in a workflow run
-            # $GITHUB_HEAD_REF does not have a value when we merge, because merging is counted as a "push" event to master branch
-            # Therefore we set this value to "master" manually
-            if [ -z "$CHART_REF" ]; then
-              export CHART_REF="master"
-            fi
-
+            # The chart for the UI repo is stored in IAC branch master
+            # If you are working on the chart for UI/API, you can modify this value manualy in releases
+            export CHART_REF="master"
             export SANDBOX_ID="STAGING_SANDBOX_ID"
             export KUBERNETES_ENV="staging"
             export IMAGE_PATTERN="^$REF_ID-[a-f0-9]+-(?P<timestamp>[0-9]+)$"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -279,8 +279,8 @@ jobs:
 
           if [ "${{ matrix.environment }}" = "staging" ]; then
 
-            # The chart for the UI repo is stored in IAC branch master
-            # If you are working on the chart for UI/API, you can modify this value manualy in releases
+            # The chart template for the UI repo is stored in IAC branch master
+            # If you are working on the chart for UI/API, you can modify this value manualy in in your PR's release
             export CHART_REF="master"
             export SANDBOX_ID="STAGING_SANDBOX_ID"
             export KUBERNETES_ENV="staging"


### PR DESCRIPTION
# Description
The UI deployment chart is stored in iac/master. Therefore, the chart repository should point to iac/master by default, not iac/<branch-name>.

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `biomage experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.