### PR TITLE
Add scroll to new cluster in cell sets tool

### DIFF
--- a/src/components/data-exploration/cell-sets-tool/CellSetsTool.jsx
+++ b/src/components/data-exploration/cell-sets-tool/CellSetsTool.jsx
@@ -1,6 +1,7 @@
 import React, {
   useEffect, useRef, useState, useCallback,
 } from 'react';
+import { animateScroll } from 'react-scroll';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 // import SubsetCellSetsOperation from 'components/data-exploration/cell-sets-tool/SubsetCellSetsOperation';
@@ -72,6 +73,20 @@ const CellSetsTool = (props) => {
   }, [hierarchy, properties]);
 
   const [numSelected, setNumSelected] = useState(0);
+
+  useEffect(() => {
+    if (!hierarchy[1]?.children || !cellSetTreeData[1]?.children) return;
+
+    const currentClusterCount = hierarchy[0].children.length;
+    const currentCustomCellSetsCount = hierarchy[1].children.length;
+    const previousCustomCellSetsCount = cellSetTreeData[1].children.length;
+
+    if (currentCustomCellSetsCount > previousCustomCellSetsCount) {
+      // scroll to bottom based on total number of cell sets, overshoot to show new cluster
+      const newHeight = (currentClusterCount + currentCustomCellSetsCount) * 30 + 200;
+      animateScroll.scrollTo(newHeight, { containerId: 'cell-set-tool-container' });
+    }
+  }, [hierarchy]);
 
   useEffect(() => {
     const selected = allSelected[activeTab];

--- a/src/components/data-exploration/cell-sets-tool/CellSetsTool.jsx
+++ b/src/components/data-exploration/cell-sets-tool/CellSetsTool.jsx
@@ -75,15 +75,15 @@ const CellSetsTool = (props) => {
   const [numSelected, setNumSelected] = useState(0);
 
   useEffect(() => {
-    if (!hierarchy[1]?.children || !cellSetTreeData[1]?.children) return;
+    const louvainClusters = hierarchy.find(({ key }) => key === 'louvain')?.children;
+    const customClusters = hierarchy.find(({ key }) => key === 'scratchpad')?.children;
+    const treeClusters = cellSetTreeData?.find(({ key }) => key === 'scratchpad')?.children;
 
-    const currentClusterCount = hierarchy[0].children.length;
-    const currentCustomCellSetsCount = hierarchy[1].children.length;
-    const previousCustomCellSetsCount = cellSetTreeData[1].children.length;
+    if (!customClusters || !treeClusters) return;
 
-    if (currentCustomCellSetsCount > previousCustomCellSetsCount) {
+    if (customClusters.length > treeClusters.length) {
       // scroll to bottom based on total number of cell sets, overshoot to show new cluster
-      const newHeight = (currentClusterCount + currentCustomCellSetsCount) * 30 + 200;
+      const newHeight = (louvainClusters.length + customClusters.length) * 30 + 200;
       animateScroll.scrollTo(newHeight, { containerId: 'cell-set-tool-container' });
     }
   }, [hierarchy]);


### PR DESCRIPTION
# Description
<!---  Write a brief description of what your code does and how it relates to the issue it is resolving or feature enhancement it is implementing. -->
Add the functionality to automatically scroll to the cell set tool position (bottom of the cell sets tree) where the new cluster has been created after its creation.

# Details
#### URL to issue
https://biomage.atlassian.net/browse/BIOMAGE-1532
<!---
  Delete this comment and include the URL of the issue the pull request is related to.
  If no issue exists for this PR, replace this comment with N/A.

  Your pull request will not pass the required checks if this is not followed.
-->

#### Link to staging deployment URL (or set N/A)
https://ui-martinfosco-ui125.scp-staging.biomage.net/
<!---
  Delete this comment and include the URL of the staging environment for this pull request.
  Refer to https://github.com/biomage-org/biomage-utils#stage on how to stage a staging environment.
  If a staging environment for testing is not necessary for this PR, replace this comment with N/A 
  and explain why a staging environment is not required for this PR.

  Your pull request will not pass the required checks if this is not followed.
-->

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in biomage-org/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `biomage experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [x] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.